### PR TITLE
Updated Budgie-level Plank theme overrides for ease of accessibility. 

### DIFF
--- a/debian/gsettings-override
+++ b/debian/gsettings-override
@@ -1,4 +1,10 @@
 [net.launchpad.plank.dock.settings]
-position='left'
-theme='Arc-Plank'
-icon-size=48
+theme='Transparent'
+position='bottom'
+items-alignment='center'
+icon-size=64
+zoom-enabled=true
+zoom-percent=150
+hide-mode='window-dodge'
+hide-delay=500
+unhide-delay=0


### PR DESCRIPTION
Larger icons, more screen space, and dodges windows by default.  Now aligned along the bottom edge of the screen for ease of access and familiarity.  Transparent background for simple UI design (can be customized by savvy users later).